### PR TITLE
Update portfolio titles to roles

### DIFF
--- a/_posts/2023-07-14-CH-app-store.md
+++ b/_posts/2023-07-14-CH-app-store.md
@@ -11,9 +11,9 @@ Created the app store product pages for the [Couple HOPES](https://couplehopes.c
 
 <a href="https://apps.apple.com/ca/app/couple-hopes/id1500199636/" target="_blank"><img src="/assets/images/CH-App-Store-1.png" class="table-wrapper" style="width:100%; max-height:20rem; object-fit:cover; overflow-y:clip; object-position: 100% 0; margin-top:2rem;" /></a>
 
-## 👩‍💻 Title & Employer
+## 👩‍💻 Roles
 
-Project Manager @ The TULiP Lab, York University
+Project Manager, Technical Writer, Content Creator
 
 ## 📌 Context
 

--- a/_posts/2023-07-14-CH-design-dev.md
+++ b/_posts/2023-07-14-CH-design-dev.md
@@ -10,9 +10,9 @@ Redesigned and developed the [Couple HOPES](https://couplehopes.com/) website.
 
 <a href="https://www.couplehopes.com" target="_blank"><img src="/assets/images/CH-site.png" class="table-wrapper" style="width:100%; max-height:20rem; object-fit:cover; overflow-y:clip; object-position: 100% 0; margin-top:2rem;" /></a>
 
-## 👩‍💻 Title & Employer
+## 👩‍💻 Roles 
 
-Project Manager @ The TULiP Lab, York University
+Project Manager, Marketing Manager, Technical Writer, Designer, Developer
 
 ## 📌 Context
 

--- a/_posts/2023-07-14-shopify-site.md
+++ b/_posts/2023-07-14-shopify-site.md
@@ -3,16 +3,16 @@ layout: post
 title: Shopify Website
 category: Design and Development
 permalink: /shopify-site/
-tags: design development prototyping writing liquid html css javascript cli
+tags: design development prototyping writing liquid html css javascript cli freelance
 ---
 
 Designed and developed a Shopify website for Dr. Candice Monson [Couple HOPES](https://couplehopes.com/) website.
 
 <a href="https://www.candicemonson.com" target="_blank"><img src="/assets/images/shopify-site.png" class="table-wrapper" style="width:100%; max-height:20rem; object-fit:cover; overflow-y:clip; object-position: 100% 0; margin-top:2rem;" /></a>
 
-## 👩‍💻 Title & Employer
+## 👩‍💻 Roles
 
-Designer, Developer & Brand Strategist (Contract) @ Dr. Candice Monson 
+Designer, Developer, Copywriter & Brand Strategist 
 
 ## 📌 Context
 


### PR DESCRIPTION
Change "Title & Employer" on portfolio example pages to "Roles" for simplification and accuracy.